### PR TITLE
Add option for future instantiation of stages

### DIFF
--- a/example/fflow_eg_mods.py
+++ b/example/fflow_eg_mods.py
@@ -5,7 +5,7 @@ import numpy as np
 
 
 class Generator():
-    def __init__(self, mean, variance, quantity):
+    def __init__(self, name, out_dir, mean, variance, quantity):
         self.mean = mean
         self.variance = variance
         self.quantity = quantity
@@ -15,7 +15,7 @@ class Generator():
 
 
 class Summarize():
-    def __init__(self, methods, replace_values=False):
+    def __init__(self, name, out_dir, methods, replace_values=False):
         self.methods = {m: getattr(np, m) for m in methods}
         self.replace_values = replace_values
 

--- a/fast_flow/__init__.py
+++ b/fast_flow/__init__.py
@@ -1,3 +1,3 @@
 import logging
 logging.basicConfig()
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/fast_flow/v1/__init__.py
+++ b/fast_flow/v1/__init__.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
-from .dict_config import read_sequence_dict
+from .dict_config import read_sequence_dict, compile_sequence_dict
 from .yaml_config import config_dict_from_yaml
 
 
-__all__ = ["read_sequence_yaml", "read_sequence_dict"]
+__all__ = ["read_sequence_yaml", "read_sequence_dict", "compile_sequence_dict"]
 
 
 def read_sequence_yaml(cfg_filename, output_dir=None, backend=None):
@@ -11,3 +11,10 @@ def read_sequence_yaml(cfg_filename, output_dir=None, backend=None):
                                 output_dir=output_dir,
                                 backend=backend)
     return read_sequence_dict(**cfg)
+
+
+def compile_sequence_yaml(cfg_filename, output_dir=None, backend=None):
+    cfg = config_dict_from_yaml(cfg_filename,
+                                output_dir=output_dir,
+                                backend=backend)
+    return compile_sequence_dict(**cfg)

--- a/fast_flow/v1/__init__.py
+++ b/fast_flow/v1/__init__.py
@@ -3,7 +3,8 @@ from .dict_config import read_sequence_dict, compile_sequence_dict
 from .yaml_config import config_dict_from_yaml
 
 
-__all__ = ["read_sequence_yaml", "read_sequence_dict", "compile_sequence_dict"]
+__all__ = ["read_sequence_yaml", "compile_sequence_yaml",
+           "read_sequence_dict", "compile_sequence_dict"]
 
 
 def read_sequence_yaml(cfg_filename, output_dir=None, backend=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.1
+current_version = 0.3.0
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="fast-flow",
-    version="0.2.1",
+    version="0.3.0",
     author="Ben Krikler",
     author_email="fast-hep@cern.ch",
     description="YAML-based analysis flow description language",

--- a/tests/test_dict_config.py
+++ b/tests/test_dict_config.py
@@ -114,3 +114,16 @@ def test_sequence_from_dict(a_stage_list, all_stage_configs, tmpdir):
     assert stages[0].an_int == 3
     assert stages[0].a_str == "hello world"
     assert len(stages[0].other_args) == 2
+
+
+def test_compile_sequence_from_dict(a_stage_list, all_stage_configs, tmpdir):
+    general = dict(backend="tests.fake_scribbler_to_test", output_dir=str(tmpdir))
+    compiled = dict_config.compile_sequence_dict(a_stage_list, general, **all_stage_configs)
+    stages = compiled()
+
+    assert len(stages) == 2
+    assert isinstance(stages[0], fakes.FakeScribblerArgs)
+    assert isinstance(stages[1], fakes.FakeScribbler)
+    assert stages[0].an_int == 3
+    assert stages[0].a_str == "hello world"
+    assert len(stages[0].other_args) == 2

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -7,11 +7,11 @@ from . import fake_scribbler_to_test as fakes
 @pytest.fixture
 def config_1(tmpdir):
     content = """
-    general: 
+    general:
         backend: tests.fake_scribbler_to_test
         output_dir: %(tmpdir)s
 
-    stages: 
+    stages:
         - my_first_stage: tests.fake_scribbler_to_test.FakeScribbler
         - my_second_stage: FakeScribblerArgs
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -28,7 +28,7 @@ def config_1(tmpdir):
 
 
 def test_read_sequence_yaml(config_1):
-    stages = fast_flow.read_sequence_yaml(config_1)
+    stages = fast_flow.read_sequence_yaml(str(config_1))
     assert len(stages) == 2
     assert isinstance(stages[0], fakes.FakeScribbler)
     assert isinstance(stages[1], fakes.FakeScribblerArgs)
@@ -38,7 +38,7 @@ def test_read_sequence_yaml(config_1):
 
 
 def test_compile_sequence_yaml(config_1):
-    stages = fast_flow.compile_sequence_yaml(config_1)
+    stages = fast_flow.compile_sequence_yaml(str(config_1))
     stages = stages()
     assert len(stages) == 2
     assert isinstance(stages[0], fakes.FakeScribbler)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,0 +1,48 @@
+from __future__ import absolute_import
+import pytest
+import fast_flow.v1 as fast_flow
+from . import fake_scribbler_to_test as fakes
+
+
+@pytest.fixture
+def config_1(tmpdir):
+    content = """
+    general: 
+        backend: tests.fake_scribbler_to_test
+        output_dir: %(tmpdir)s
+
+    stages: 
+        - my_first_stage: tests.fake_scribbler_to_test.FakeScribbler
+        - my_second_stage: FakeScribblerArgs
+
+    my_first_stage: {}
+    my_second_stage:
+        an_int: 3
+        a_str: hello world
+        some_other_arg: True
+        yet_more_arg: [0, 1, 2]
+    """ % dict(tmpdir=str(tmpdir))
+    out_file = tmpdir / "config.yml"
+    out_file.write(content)
+    return out_file
+
+
+def test_read_sequence_yaml(config_1):
+    stages = fast_flow.read_sequence_yaml(config_1)
+    assert len(stages) == 2
+    assert isinstance(stages[0], fakes.FakeScribbler)
+    assert isinstance(stages[1], fakes.FakeScribblerArgs)
+    assert stages[1].an_int == 3
+    assert stages[1].a_str == "hello world"
+    assert len(stages[1].other_args) == 2
+
+
+def test_compile_sequence_yaml(config_1):
+    stages = fast_flow.compile_sequence_yaml(config_1)
+    stages = stages()
+    assert len(stages) == 2
+    assert isinstance(stages[0], fakes.FakeScribbler)
+    assert isinstance(stages[1], fakes.FakeScribblerArgs)
+    assert stages[1].an_int == 3
+    assert stages[1].a_str == "hello world"
+    assert len(stages[1].other_args) == 2


### PR DESCRIPTION
This allows a caller of fast-flow to only instantiate stages at a later date by adding a new method called `compile_sequence_yaml` and `compile_sequence_dict`.  The returned object can simply be called directly to obtain the list of instantiated stages.