### PR TITLE
Fix backend as module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+## [0.6.1] - 2020-08-06
+### Fixed
+- Fix regression for handling of backend being a module rather than a string to module, PR #17 [@benkrikler](https://github.com/benkrikler)
+
 ## [0.6.0] - 2020-08-01
 ### Added
 - Option to return the expanded config (strip out imports) PR #15 [@benkrikler](https://github.com/benkrikler)

--- a/fast_flow/v1/yaml_config.py
+++ b/fast_flow/v1/yaml_config.py
@@ -14,6 +14,9 @@ def _load_yaml(filename):
 def config_dict_from_yaml(cfg_filename, output_dir=None, backend=None):
     cfg = _load_yaml(cfg_filename)
 
+    this_dir = os.path.dirname(cfg_filename)
+    cfg = expand_imports(cfg, this_dir=this_dir)
+
     # Override the output_dir in the config file if this function is given one
     if "general" not in cfg:
         cfg["general"] = {}
@@ -21,9 +24,6 @@ def config_dict_from_yaml(cfg_filename, output_dir=None, backend=None):
         cfg["general"]["output_dir"] = output_dir
     if backend:
         cfg["general"]["backend"] = backend
-
-    this_dir = os.path.dirname(cfg_filename)
-    cfg = expand_imports(cfg, this_dir=this_dir)
 
     return cfg
 
@@ -34,11 +34,12 @@ _StageDescription = namedtuple("_StageDescription", "name type config")
 def expand_imports(cfg, this_dir):
     cfg = copy.deepcopy(cfg)
     stages = cfg.pop("stages")
-    general = cfg.pop("general")
+    general = cfg.pop("general", None)
 
     internal_stage_list = preprocess_imports(stages, cfg, this_dir)
     expanded_cfg = build_config(internal_stage_list)
-    expanded_cfg["general"] = general
+    if general is not None:
+        expanded_cfg["general"] = general
     return expanded_cfg
 
 

--- a/fast_flow/version.py
+++ b/fast_flow/version.py
@@ -12,5 +12,5 @@ def split_version(version):
     return tuple(result)
 
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 version_info = split_version(__version__) # noqa

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 0.6.1
 commit = True
 tag = False
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -114,7 +114,7 @@ def test_compile_sequence_yaml(config_1):
 
 
 def test_compile_sequence_yaml_import(config_2):
-    stages = fast_flow.compile_sequence_yaml(str(config_2), backend="tests.fake_scribbler_to_test")
+    stages = fast_flow.compile_sequence_yaml(str(config_2), backend=fakes)
     stages = stages()
     assert len(stages) == 5
     assert isinstance(stages[0], fakes.FakeScribbler)
@@ -128,7 +128,7 @@ def test_compile_sequence_yaml_import(config_2):
 
 
 def test_read_return_cfg(config_2):
-    stages, cfg = fast_flow.read_sequence_yaml(str(config_2), backend="tests.fake_scribbler_to_test", return_cfg=True)
+    stages, cfg = fast_flow.read_sequence_yaml(str(config_2), backend=fakes, return_cfg=True)
     assert len(stages) == 5
     assert len(cfg) == 7
     assert "stages" in cfg


### PR DESCRIPTION
v0.6.0 introduced a regression that prevented module objects being passed into the main fast-flow entry points as a backend which broke the Python API.    This fixes that issue.